### PR TITLE
adds support for specifying {:system, "PORT"} as valid port value.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ curl -i localhost:4080
 
 ```elixir
 config :master_proxy,
-  http: [port: 80],
+  http: [port: {:system, "PORT"}], # reads $PORT env variable at runtime.
   backends: [
     %{
       host: ~r{^app-name\.gigalixirapp\.com$},

--- a/lib/master_proxy/application.ex
+++ b/lib/master_proxy/application.ex
@@ -37,6 +37,7 @@ defmodule MasterProxy.Application do
   defp port_to_integer(:undefined),
     do: raise("port is missing from the master_proxy configuration")
 
+  defp port_to_integer({:system, var_name}), do: port_to_integer(System.get_env(var_name))
   defp port_to_integer(port) when is_binary(port), do: String.to_integer(port)
   defp port_to_integer(port) when is_integer(port), do: port
 end


### PR DESCRIPTION
This is aligned with a similar form that Phoenix supports making the usage more familiar.