### PR TITLE
Add `:server` option, Improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,14 @@
 # MasterProxy
 
-Proxies requests to Web apps that are part of the platform. Useful for Gigalixir, Render or Heroku deployment when only one web port is exposed.
+Route requests to other Phoenix Endpoints or Plugs with WebSocket support.
 
-Works with Phoenix Endpoints, Plugs and WebSockets.
-
-This application is based on the [master_proxy](https://github.com/wojtekmach/acme_bank/tree/master/apps/master_proxy) application inside the [acme_bank](https://github.com/wojtekmach/acme_bank) project, which was based on a gist shared by [Gazler](https://github.com/Gazler).
+> This library is useful for Gigalixir, Render or Heroku deployment when only one web port is exposed.
 
 ## Installation
 
 Add `master_proxy` to your list of dependencies in `mix.exs`.
 
-Note: if you are running an umbrella project, adding MasterProxy as a dependency at the root `mix.exs` won't work. Instead, either add it to one of your child apps or create a new child app solely for the proxy.
+> If you are running an umbrella project, adding `master_proxy` as a dependency at the root `mix.exs` won't work. Instead, either add it to one of your child apps or create a new child app solely for the proxy.
 
 ```elixir
 def deps do
@@ -20,11 +18,10 @@ def deps do
 end
 ```
 
-Configure how MasterProxy should route requests by adding something like this in `config.exs`.
+Configure rules for routing requests by adding something like this in `config.exs`.
 
 ```elixir
-config :master_proxy, 
-  # any Cowboy options are allowed
+config :master_proxy,
   http: [:inet6, port: 4080],
   https: [:inet6, port: 4443],
   backends: [
@@ -41,7 +38,7 @@ config :master_proxy,
   ]
 ```
 
-For further configuration examples, see below.
+See [Configuration Examples](#configuration-examples) for more.
 
 To avoid the platform routing requests directly to your Web apps' Endpoints, and thus bypassing the Endpoint on which MasterProxy is running, you can configure your other Web apps' Endpoints to not start a server in your production config.
 
@@ -52,23 +49,20 @@ config :my_app_web, MyAppWeb.Endpoint,
   server: false
 ```
 
-## How does proxying work?
+## Available Options
 
-1. We start a Cowboy server with a single dispatch handler: `MasterProxy.Cowboy2Handler`.
-2. The handler checks the verb, host and path of the request, and compares them to the supplied configuration to determine where to route the request.
-	1. If the backend that matched is a `phoenix_endpoint`, MasterProxy delegates to the Phoenix.Endpoint.Cowboy2Handler with your app's Endpoint.
-	2. If the backend that matched is a `plug`, MasterProxy simply calls the plug as normal.
-	3. If no backend is matched, a text response with a status code of 404 is returned.
+- `:http` - the configuration for the HTTP server. It accepts all options as defined by [Plug.Cowboy](https://hexdocs.pm/plug_cowboy/).
+- `:https` - the configuration for the HTTPS server. It accepts all options as defined by [Plug.Cowboy](https://hexdocs.pm/plug_cowboy/).
+- `:server` - `true` by default. If you are running application with `mix phx.server`, this option is ignored, and the server will always be started.
+- `:backends` - the rule for routing requests. See [Configuration Examples](#configuration-examples) for more.
+  - `:verb`
+  - `:host`
+  - `:path`
+  - `:phoenix_endpoint` / `:plug`
+  - `:opts` - only for `:plug`
+- `:log_requests` - `true` by default. Log the requests or not.
 
-## Development
-
-```bash
-mix run --no-halt
-curl -i foo.com.127.0.0.1.xip.io:4080 
-curl -i localhost:4080
-```
-
-## Configuration examples
+## Configuration Examples
 
 ### Route requests to apps based on hostname
 
@@ -94,3 +88,23 @@ config :master_proxy,
     }
   ]
 ```
+
+## How does it work?
+
+1. We start a Cowboy server with a single dispatch handler: `MasterProxy.Cowboy2Handler`.
+2. The handler checks the verb, host and path of the request, and compares them to the supplied configuration to determine where to route the request.
+3. If the backend that matched is a Phoenix Endpoint, MasterProxy delegates to the `Phoenix.Endpoint.Cowboy2Handler` with your app's Endpoint.
+4. If the backend that matched is a plug, MasterProxy simply calls the plug as normal.
+5. If no backend is matched, a text response with a status code of 404 is returned.
+
+## Development
+
+```bash
+mix run --no-halt
+curl -i foo.com.127.0.0.1.xip.io:4080
+curl -i localhost:4080
+```
+
+## Thanks
+
+This application is based on the [master_proxy](https://github.com/wojtekmach/acme_bank/tree/master/apps/master_proxy) application inside the [acme_bank](https://github.com/wojtekmach/acme_bank) project, which was based on a gist shared by [Gazler](https://github.com/Gazler).

--- a/lib/master_proxy/application.ex
+++ b/lib/master_proxy/application.ex
@@ -7,30 +7,44 @@ defmodule MasterProxy.Application do
     import Supervisor.Spec, warn: false
 
     children =
-      Enum.reduce([:http, :https], [], fn scheme, result ->
-        case Application.get_env(:master_proxy, scheme) do
-          nil ->
-            # no config for this scheme, that's ok, just skip
-            result
+      if server?() do
+        Enum.reduce([:http, :https], [], fn scheme, result ->
+          case Application.get_env(:master_proxy, scheme) do
+            nil ->
+              # no config for this scheme, that's ok, just skip
+              result
 
-          scheme_opts ->
-            port = :proplists.get_value(:port, scheme_opts)
-            dispatch = [{:_, [{:_, MasterProxy.Cowboy2Handler, {nil, nil}}]}]
+            scheme_opts ->
+              port = :proplists.get_value(:port, scheme_opts)
+              dispatch = [{:_, [{:_, MasterProxy.Cowboy2Handler, {nil, nil}}]}]
 
-            opts =
-              [
-                port: port_to_integer(port),
-                dispatch: dispatch
-              ] ++ :proplists.delete(:port, scheme_opts)
+              opts =
+                [
+                  port: port_to_integer(port),
+                  dispatch: dispatch
+                ] ++ :proplists.delete(:port, scheme_opts)
 
-            Logger.info("[master_proxy] Listening on #{scheme} with options: #{inspect(opts)}")
+              Logger.info("[master_proxy] Listening on #{scheme} with options: #{inspect(opts)}")
 
-            [{Plug.Cowboy, scheme: scheme, plug: {nil, nil}, options: opts} | result]
-        end
-      end)
+              [{Plug.Cowboy, scheme: scheme, plug: {nil, nil}, options: opts} | result]
+          end
+        end)
+      else
+        []
+      end
 
     opts = [strategy: :one_for_one, name: MasterProxy.Supervisor]
+
     Supervisor.start_link(children, opts)
+  end
+
+  defp server?() do
+    # the server will be started in following situations:
+    # + enable `server: true` option for master_proxy (by default)
+    # + run `iex -S mix phx.server`
+    # + run `mix phx.server`
+    Application.get_env(:phoenix, :serve_endpoints, false) ||
+      Application.get_env(:master_proxy, :server, true)
   end
 
   # :undefined is what :proplist.get_value returns


### PR DESCRIPTION
1. add `:server` option:
   + by default, it is `true`, which helps to keep the original behavior.
   + it will be ignored when running with `iex -S mix phx.server` or `mix phx.server`. And the server is started even though `server: false`, which is useful in dev environment.
> It solves #8, maybe.
   
2. improve docs, such as:
   + available options.
   + in-page hyperlink.
   + ……
   
Feel free to merge or modify it. 