### PR TITLE
Improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ end
 >
 > ```elixir
 > config :main_proxy,
+>   http: [port: 4080],
+>   https: [port: 4443],
 >   backends: [
 >     # ...
 >   ]
@@ -91,7 +93,7 @@ config :my_app_members, MyAppMembersWeb.Endpoint, server: false
 - `:http` - the configuration for the HTTP server. It accepts all options as defined by [Plug.Cowboy](https://hexdocs.pm/plug_cowboy/).
 - `:https` - the configuration for the HTTPS server. It accepts all options as defined by [Plug.Cowboy](https://hexdocs.pm/plug_cowboy/).
 - `:server` - `true` by default. If you are running application with `mix phx.server`, this option is ignored, and the server will always be started.
-- `:backends` - the rule for routing requests. See [Configuration Examples](#configuration-examples) for more.
+- `:backends` - the rule for routing requests:
   - `:domain`
   - `:verb`
   - `:host`
@@ -99,55 +101,6 @@ config :my_app_members, MyAppMembersWeb.Endpoint, server: false
   - `:phoenix_endpoint` / `:plug`
   - `:opts` - only for `:plug`
 - `:log_requests` - `true` by default. Log the requests or not.
-
-## Configuration Examples
-
-### Route requests to apps based on hostname
-
-```elixir
-defmodule MyApp.Proxy do
-  use MainProxy.Proxy
-
-  @impl MainProxy.Proxy
-  def backends do
-    [
-      %{
-        host: ~r{^app-name\.gigalixirapp\.com$},
-        phoenix_endpoint: MyAppWeb.Endpoint
-      },
-      %{
-        host: ~r{^www\.example\.com$},
-        phoenix_endpoint: MyAppWeb.Endpoint
-      },
-      %{
-        host: ~r{^api\.example\.com$},
-        phoenix_endpoint: MyAppApiWeb.Endpoint
-      },
-      %{
-        host: ~r{^members\.example\.com$},
-        phoenix_endpoint: MyAppMembersWeb.Endpoint
-      }
-    ]
-  end
-end
-```
-
-### Configuration via application config
-
-```elixir
-config :main_proxy,
-  http: [port: 80],
-  backends: [
-    %{
-      host: ~r{^app-name\.gigalixirapp\.com$},
-      phoenix_endpoint: MyAppWeb.Endpoint
-    },
-    %{
-      host: ~r{^www\.example\.com$},
-      phoenix_endpoint: MyAppWeb.Endpoint
-    }
-  ]
-```
 
 <!-- MDOC !-->
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ config :my_app_members, MyAppMembersWeb.Endpoint, server: false
 
 ## How does MainProxy work?
 
-1. We start a Cowboy server with a single dispatch handler: `MainProxy.Cowboy2Handler`.
+1. MainProxy starts a Cowboy server with a single dispatch handler: `MainProxy.Cowboy2Handler`.
 2. The handler checks the verb, host and path of the request, and compares them to the supplied configuration to determine where to route the request.
 3. If the backend that matched is a `phoenix_endpoint`, MainProxy delegates to the `Phoenix.Endpoint.Cowboy2Handler` with your app's Endpoint.
 4. If the backend that matched is a `plug`, MainProxy calls the plug as normal.
@@ -122,4 +122,7 @@ curl -i localhost:4080
 
 ## Thanks
 
-This application is based on the [main_proxy](https://github.com/wojtekmach/acme_bank/tree/master/apps/main_proxy) application inside the [acme_bank](https://github.com/wojtekmach/acme_bank) project, which was based on a gist shared by [Gazler](https://github.com/Gazler).
+This library is based on:
+
+- [master_proxy](https://github.com/wojtekmach/acme_bank/tree/master/apps/master_proxy) application inside the [acme_bank](https://github.com/wojtekmach/acme_bank) project from [wojtekmach](https://github.com/wojtekmach).
+- [master_proxy.ex](https://gist.github.com/Gazler/fe7ed5dc598250002dfe) from [Gazler](https://github.com/Gazler).

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ See [Configuration Examples](#module-configuration-examples) for more.
 Then create the proxy module and add it to your application startup (often in `MyApp.Application`):
 
 module:
-``` elixir
+
+```elixir
 defmodule MyApp.Proxy do
   use MainProxy.Proxy
 
@@ -87,18 +88,19 @@ config :my_app_web, MyAppWeb.Endpoint,
 ## Available Options
 
 - `:http` - the configuration for the HTTP server. It accepts all options as defined by [Plug.Cowboy](https://hexdocs.pm/plug_cowboy/).
- - `:https` - the configuration for the HTTPS server. It accepts all options as defined by [Plug.Cowboy](https://hexdocs.pm/plug_cowboy/).
- - `:server` - `true` by default. If you are running application with `mix phx.server`, this option is ignored, and the server will always be started.
- - `:backends` - the rule for routing requests. See [Configuration Examples](#configuration-examples) for more.
-   - `:domain`
-   - `:verb`
-   - `:host`
-   - `:path`
-   - `:phoenix_endpoint` / `:plug`
-   - `:opts` - only for `:plug`
- - `:log_requests` - `true` by default. Log the requests or not.
+- `:https` - the configuration for the HTTPS server. It accepts all options as defined by [Plug.Cowboy](https://hexdocs.pm/plug_cowboy/).
+- `:server` - `true` by default. If you are running application with `mix phx.server`, this option is ignored, and the server will always be started.
+- `:backends` - the rule for routing requests. See [Configuration Examples](#configuration-examples) for more.
+  - `:domain`
+  - `:verb`
+  - `:host`
+  - `:path`
+  - `:phoenix_endpoint` / `:plug`
+  - `:opts` - only for `:plug`
+- `:log_requests` - `true` by default. Log the requests or not.
 
 <a id="module-configuration-examples"></a>
+
 ## Configuration Examples
 
 ### Route requests to apps based on hostname
@@ -133,7 +135,7 @@ end
 
 ### Configuration via application config
 
-``` elixir
+```elixir
 config :main_proxy,
   http: [port: 80],
   backends: [
@@ -168,4 +170,4 @@ curl -i localhost:4080
 
 ## Thanks
 
- This application is based on the [main_proxy](https://github.com/wojtekmach/acme_bank/tree/master/apps/main_proxy) application inside the [acme_bank](https://github.com/wojtekmach/acme_bank) project, which was based on a gist shared by [Gazler](https://github.com/Gazler).
+This application is based on the [main_proxy](https://github.com/wojtekmach/acme_bank/tree/master/apps/main_proxy) application inside the [acme_bank](https://github.com/wojtekmach/acme_bank) project, which was based on a gist shared by [Gazler](https://github.com/Gazler).


### PR DESCRIPTION
This PR modifies `README.md` to make it **describe the happy path to install and run `main_proxy`**, and adds some minor changes, such as:
+ format README.md
+ remove distracting contents
+ ...

Every commit is self-described. And, feel free to give suggestion, I will change it as you need.

Note: You can preview the result on my branch - https://github.com/plastic-forks/main_proxy/tree/improve-docs