### PR TITLE
Use Logger.warning instead of Logger.warn

### DIFF
--- a/lib/main_proxy.ex
+++ b/lib/main_proxy.ex
@@ -62,7 +62,7 @@ defmodule MainProxy do
         backends
 
       :error ->
-        Logger.warn(
+        Logger.warning(
           "No backends specified. Either configure :main_proxy, :backends or define a " <>
             "`backend/0` function in your `Proxy` module."
         )

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule MainProxy.MixProject do
       description:
         "Proxies requests to multiple apps. Useful for Gigalixir or Heroku deployment when just one web port is exposed. Works with phoenix endpoints, plugs, and websockets.",
       package: package(),
-      elixir: "~> 1.9",
+      elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
The goal is to silence Elixir compiler complaining about using Logger.warn instead of Logger.warning.

I also had to bump minimal Elixir version to 1.11, since the Logger.warning was introduced in Elixir 1.11.